### PR TITLE
Fix camera picker navigation issue

### DIFF
--- a/screens/CameraScreen.js
+++ b/screens/CameraScreen.js
@@ -19,7 +19,9 @@ export default function CameraScreen({ navigation }) {
         if (!hasPermission) return Alert.alert('No permission', 'Allow camera in settings.');
         try {
             const result = await ImagePicker.launchCameraAsync({ quality: 0.8 });
-            if (!result.cancelled) navigation.replace('Analysis', { imageUri: result.uri });
+            if (!result.canceled && result.assets && result.assets.length > 0) {
+                navigation.replace('Analysis', { imageUri: result.assets[0].uri });
+            }
         } catch {
             Alert.alert('Error', 'Cannot open camera.');
         }


### PR DESCRIPTION
## Summary
- correct property names when extracting data from expo-image-picker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68411e52e1e08322a112a976d383fbc1