### PR TITLE
Add Jest setup and OpenAI service test

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -28,7 +29,16 @@
     "react-native-reanimated": "~3.16.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.20.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "preset": "react-native",
+    "transform": {
+      "^.+\\.js$": "babel-jest"
+    },
+    "testEnvironment": "node"
   },
   "private": true
 }

--- a/services/__tests__/OpenAI.test.js
+++ b/services/__tests__/OpenAI.test.js
@@ -1,0 +1,59 @@
+import { analyzeImageWithOpenAI } from '../OpenAI';
+
+describe('analyzeImageWithOpenAI', () => {
+  const mockResponse = {
+    choices: [{ message: { content: 'ok' } }],
+    usage: {}
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(mockResponse)
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls fetch with correct URL and body', async () => {
+    const imageUrl = 'http://example.com/img.png';
+    const profile = { foo: 'bar' };
+
+    await analyzeImageWithOpenAI(imageUrl, profile);
+
+    const expectedBody = {
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: `User Profile: ${JSON.stringify(profile)}` },
+            {
+              type: 'text',
+              text:
+                'Extract all ingredients from this image, rate safety A–F, flag child/adult concerns, identify dangerous ingredient pairs (synergy×synergy), and suggest one‑tap “Smarter Swap” alternatives.'
+            },
+            { type: 'image_url', image_url: { url: imageUrl } }
+          ]
+        }
+      ],
+      max_tokens: 500,
+      temperature: 0.2
+    };
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer YOUR_API_KEY',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(expectedBody)
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest in `package.json`
- add `babel.config.js` for Babel preset
- create `services/__tests__/OpenAI.test.js` with fetch mock

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411f4a53708322bd71658f5ac2cc39