### PR TITLE
Fix camera cancel check

### DIFF
--- a/screens/CameraScreen.js
+++ b/screens/CameraScreen.js
@@ -19,7 +19,7 @@ export default function CameraScreen({ navigation }) {
         if (!hasPermission) return Alert.alert('No permission', 'Allow camera in settings.');
         try {
             const result = await ImagePicker.launchCameraAsync({ quality: 0.8 });
-            if (!result.cancelled) navigation.replace('Analysis', { imageUri: result.uri });
+            if (!result.canceled) navigation.replace('Analysis', { imageUri: result.uri });
         } catch {
             Alert.alert('Error', 'Cannot open camera.');
         }


### PR DESCRIPTION
## Summary
- handle the `result.canceled` property to avoid navigating when the photo is canceled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68411f3b53448322ad0bdebf3c6a04a6