### PR TITLE
Embed image data for OpenAI

### DIFF
--- a/services/OpenAI.js
+++ b/services/OpenAI.js
@@ -1,7 +1,18 @@
 ﻿
 import Constants from 'expo-constants';
+import * as FileSystem from 'expo-file-system';
 
 export async function analyzeImageWithOpenAI(imageUrl, profile = {}) {
+    let dataUri = imageUrl;
+    try {
+        const base64 = await FileSystem.readAsStringAsync(imageUrl, {
+            encoding: FileSystem.EncodingType.Base64,
+        });
+        dataUri = `data:image/jpeg;base64,${base64}`;
+    } catch (e) {
+        // Failed to read local file; fall back to original URL
+    }
+
     const messages = [
         {
             role: 'user',
@@ -11,7 +22,7 @@ export async function analyzeImageWithOpenAI(imageUrl, profile = {}) {
                     type: 'text',
                     text: 'Extract all ingredients from this image, rate safety A–F, flag child/adult concerns, identify dangerous ingredient pairs (synergy×synergy), and suggest one‑tap “Smarter Swap” alternatives.'
                 },
-                { type: 'image_url', image_url: { url: imageUrl } }
+                { type: 'image_url', image_url: { url: dataUri } }
             ]
         }
     ];

--- a/services/__tests__/OpenAI.test.js
+++ b/services/__tests__/OpenAI.test.js
@@ -1,4 +1,5 @@
 import { analyzeImageWithOpenAI } from '../OpenAI';
+import * as FileSystem from 'expo-file-system';
 
 describe('analyzeImageWithOpenAI', () => {
   const mockResponse = {
@@ -7,6 +8,7 @@ describe('analyzeImageWithOpenAI', () => {
   };
 
   beforeEach(() => {
+    jest.spyOn(FileSystem, 'readAsStringAsync').mockResolvedValue('YmFzZTY0');
     global.fetch = jest.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve(mockResponse)
@@ -19,7 +21,7 @@ describe('analyzeImageWithOpenAI', () => {
   });
 
   it('calls fetch with correct URL and body', async () => {
-    const imageUrl = 'http://example.com/img.png';
+    const imageUrl = 'file:///example/img.png';
     const profile = { foo: 'bar' };
 
     await analyzeImageWithOpenAI(imageUrl, profile);
@@ -36,7 +38,7 @@ describe('analyzeImageWithOpenAI', () => {
               text:
                 'Extract all ingredients from this image, rate safety A–F, flag child/adult concerns, identify dangerous ingredient pairs (synergy×synergy), and suggest one‑tap “Smarter Swap” alternatives.'
             },
-            { type: 'image_url', image_url: { url: imageUrl } }
+            { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,YmFzZTY0' } }
           ]
         }
       ],


### PR DESCRIPTION
## Summary
- embed local photos in OpenAI requests by converting to base64
- adjust service unit test for new behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412708fd988322996706a844f42b66