### PR TITLE
Improve OpenAI request error handling

### DIFF
--- a/services/OpenAI.js
+++ b/services/OpenAI.js
@@ -18,23 +18,31 @@ export async function analyzeImageWithOpenAI(imageUrl, profile = {}) {
 
     const apiKey = Constants.expoConfig?.extra?.openaiApiKey || process.env.OPENAI_API_KEY;
 
-    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: "POST",
-        headers: {
-            'Authorization': `Bearer ${apiKey}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            model: "gpt-4o-mini",
-            messages,
-            max_tokens: 500,
-            temperature: 0.2
-        })
-    });
+    try {
+        const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                messages,
+                max_tokens: 500,
+                temperature: 0.2
+            })
+        });
 
-    const json = await resp.json();
-    return {
-        text: json.choices[0].message.content,
-        usage: json.usage
-    };
+        const json = await resp.json();
+        if (!resp.ok) {
+            throw new Error(json.error?.message || json.error || `Request failed with status ${resp.status}`);
+        }
+
+        return {
+            text: json.choices[0].message.content,
+            usage: json.usage
+        };
+    } catch (err) {
+        return { error: err.message };
+    }
 }

--- a/services/__tests__/OpenAI.test.js
+++ b/services/__tests__/OpenAI.test.js
@@ -9,6 +9,7 @@ describe('analyzeImageWithOpenAI', () => {
   beforeEach(() => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
+        ok: true,
         json: () => Promise.resolve(mockResponse)
       })
     );


### PR DESCRIPTION
## Summary
- handle failed responses from OpenAI
- surface error messages in AnalysisScreen
- update OpenAI tests for new response shape

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684127168c848322a5bd936a5660b247